### PR TITLE
Fixed auto-populate issue on the config page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>tfs-branch-source-plugin</groupId>
   <artifactId>tfs_branch_source</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <packaging>hpi</packaging>
 
   <properties>

--- a/src/main/java/tfsbranchsourceplugin/tfs_branch_source/MultiBranchPipelineBuilder.java
+++ b/src/main/java/tfsbranchsourceplugin/tfs_branch_source/MultiBranchPipelineBuilder.java
@@ -38,9 +38,9 @@ import java.util.List;
 
 public class MultiBranchPipelineBuilder extends Builder implements SimpleBuildStep {
 
-    private final String teamProjectUrl;
-    private final String credentialsId;
-    private final String projectRecognizer;
+    public final String teamProjectUrl;
+    public final String credentialsId;
+    public final String projectRecognizer;
 
 
     @DataBoundConstructor
@@ -49,10 +49,6 @@ public class MultiBranchPipelineBuilder extends Builder implements SimpleBuildSt
         this.credentialsId = credentialsId;
         this.projectRecognizer = projectRecognizer;
 
-    }
-
-    public String getCredentialsId() {
-        return credentialsId;
     }
 
     @Override


### PR DESCRIPTION
Jenkins conventions deem it necessary to have either  the fields be public or have public getters for each.  I went with the former, because IDEs don't like the latter.  They grey out the functions saying the functions are never used.